### PR TITLE
Add require so the namespace with the implementation gets loaded

### DIFF
--- a/src/multi_metodos/core.clj
+++ b/src/multi_metodos/core.clj
@@ -1,5 +1,6 @@
 (ns multi-metodos.core
-  (:require [multi-metodos.executar :as exe]))
+  (:require [multi-metodos.executar :as exe]
+            multi-metodos.email))
 
 (defn -main []
   (println "Ola")


### PR DESCRIPTION
If no one `:require`s a namespace, the code inside isn't run,
 so clojure has no way of knowing about the `defmethod`.

Integrant has [a helper](https://weavejester.github.io/integrant/integrant.core.html#var-load-namespaces) for this.